### PR TITLE
Fixing validation on "Would you like to run another option?"

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -38,8 +38,20 @@ namespace UtilityBelt
         {
             Console.WriteLine("");
             Console.ForegroundColor = ConsoleColor.Green;
-            Console.Write("Would you like to run another option?: ");
-            string testUserInput = Console.ReadLine();
+
+            string testUserInput = null;
+            do
+            {
+                Console.Write("Would you like to run another option?: ");
+                testUserInput = Console.ReadLine();
+                if (int.TryParse(testUserInput, out _)) //If user input was a number...
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("I am sorry, your answer could not be translated to a yes/no.");
+                    Console.WriteLine("Please try to reformat your answer.\n");
+                    testUserInput = null;
+                }
+            } while (testUserInput == null);
 
             try
             {


### PR DESCRIPTION
Firstly, thanks so much for making this. As a beginner I've found most of the Hacktoberfest challenges completely out of my league!

I found that when you are prompted with "Would you like to run another option?" you could push a number and it would treat it as "yes". I tested this with the '5' specifically.

This pull request includes the checking of user input for numbers. If there is a number it will tell the user it's not valid and prompt again.