### PR TITLE
Fixed null reference error when cat fact JSON doesnt contain 'status'…

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -248,10 +248,15 @@ namespace UtilityBelt
             }
             CatFactModel catFact = JsonSerializer.Deserialize<CatFactModel>(content);
             Console.WriteLine();
-            if (catFact.status.verified)
+            if (catFact.status != null && catFact.status.verified)
+            {
                 Console.ForegroundColor = ConsoleColor.Yellow;
+
+            }
             else
+            {
                 Console.ForegroundColor = ConsoleColor.Red;
+            }
             Console.WriteLine(catFact.text);
             Console.WriteLine();
         }


### PR DESCRIPTION
This PR addresses the bug described in issue #25
Null check has been added to the catFact.status object before accessing its 'catFact.status.verified' field 